### PR TITLE
Title: Fix star-background sizing on scroll and restore theme background classes

### DIFF
--- a/src/components/ui/background/dark-mode/StarsBackground.tsx
+++ b/src/components/ui/background/dark-mode/StarsBackground.tsx
@@ -79,9 +79,15 @@ export const StarsBackground: FC<StarBackgroundProps> = ({
         if (!ctx) return;
 
         // Use full document dimensions to cover entire scrollable content
-        const width = Math.max(document.documentElement.scrollWidth, window.innerWidth);
-        const height = Math.max(document.documentElement.scrollHeight, window.innerHeight);
-        
+        const width = Math.max(
+          document.documentElement.scrollWidth,
+          window.innerWidth
+        );
+        const height = Math.max(
+          document.documentElement.scrollHeight,
+          window.innerHeight
+        );
+
         canvas.width = width;
         canvas.height = height;
         setStars(generateStars(width, height));
@@ -131,7 +137,10 @@ export const StarsBackground: FC<StarBackgroundProps> = ({
   return (
     <canvas
       ref={canvasRef}
-  className={cn('absolute inset-0 w-full pointer-events-none -z-10', className)}
+      className={cn(
+        'pointer-events-none absolute inset-0 -z-10 w-full',
+        className
+      )}
     />
   );
 };

--- a/src/components/ui/background/light-mode/StartsBackgroundLight.tsx
+++ b/src/components/ui/background/light-mode/StartsBackgroundLight.tsx
@@ -91,9 +91,15 @@ export const StarsBackgroundLight: FC<StarBackgroundProps> = ({
         if (!ctx) return;
 
         // Use full document dimensions to cover entire scrollable content
-        const width = Math.max(document.documentElement.scrollWidth, window.innerWidth);
-        const height = Math.max(document.documentElement.scrollHeight, window.innerHeight);
-        
+        const width = Math.max(
+          document.documentElement.scrollWidth,
+          window.innerWidth
+        );
+        const height = Math.max(
+          document.documentElement.scrollHeight,
+          window.innerHeight
+        );
+
         canvas.width = width;
         canvas.height = height;
         setStars(generateStars(width, height));
@@ -157,7 +163,10 @@ export const StarsBackgroundLight: FC<StarBackgroundProps> = ({
   return (
     <canvas
       ref={canvasRef}
-  className={cn('absolute inset-0 w-full pointer-events-none -z-10', className)}
+      className={cn(
+        'pointer-events-none absolute inset-0 -z-10 w-full',
+        className
+      )}
     />
   );
 };


### PR DESCRIPTION
Fixes an issue where the stars background showed the fallback color when scrolling on mobile by sizing the canvas to the full document (using document dimensions) and using absolute positioning.
Restores [backgroundClass](vscode-file://vscode-app/c:/Users/joaqu/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) usage from [backgroundConfig.ts](vscode-file://vscode-app/c:/Users/joaqu/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so the theme background colors are applied as before.
Removes redundant logic (e.g. ResizeObserver and manual CSS sizing) and simplifies the resize handling to a single [window.resize](vscode-file://vscode-app/c:/Users/joaqu/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) listener.
Files changed:
[StarsBackground.tsx](vscode-file://vscode-app/c:/Users/joaqu/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[StartsBackgroundLight.tsx](vscode-file://vscode-app/c:/Users/joaqu/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[backgroundConfig.ts](vscode-file://vscode-app/c:/Users/joaqu/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)